### PR TITLE
Added option to disable removing of optional attribute quotes

### DIFF
--- a/htmlmin/command.py
+++ b/htmlmin/command.py
@@ -63,15 +63,15 @@ put two of them: <!--!! comment -->.
 
 parser.add_argument('-s', '--remove-empty-space',
   help=(
-'''When set, this removes empty space betwen tags in certain cases. 
+'''When set, this removes empty space betwen tags in certain cases.
 Specifically, it will remove empty space if and only if there a newline
-character occurs within the space. Thus, code like 
+character occurs within the space. Thus, code like
 '<span>x</span> <span>y</span>' will be left alone, but code such as
 '   ...
   </head>
   <body>
     ...'
-will become '...</head><body>...'. Note that this CAN break your 
+will become '...</head><body>...'. Note that this CAN break your
 html if you spread two inline tags over two lines. Use with caution.
 
 '''),
@@ -84,6 +84,13 @@ likely will cause unintended consequences. For instance, '<i>X</i> <i>Y</i>'
 will become '<i>X</i><i>Y</i>'. Putting whitespace along with other text will
 avoid this problem. Only use if you are confident in the result. Whitespace is
 not removed from inside of tags, thus '<span> </span>' will be left alone.
+
+'''),
+  action='store_true')
+
+parser.add_argument('--keep-optional-attribute-quotes',
+  help=(
+'''When set, this keeps all attribute quotes, even if they are optional.
 
 '''),
   action='store_true')
@@ -107,7 +114,7 @@ keep the 'pre' attributes in place.
 
 parser.add_argument('-a', '--pre-attr',
   help=(
-'''The attribute htmlmin looks for to find blocks of HTML that it should not 
+'''The attribute htmlmin looks for to find blocks of HTML that it should not
 minify. This attribute will be removed from the HTML unless '-k' is
 specified. Defaults to 'pre'.
 
@@ -136,6 +143,7 @@ def main():
   minifier = Minifier(
     remove_comments=args.remove_comments,
     remove_empty_space=args.remove_empty_space,
+    remove_optional_attribute_quotes=not args.keep_optional_attribute_quotes,
     pre_tags=args.pre_tags,
     keep_pre=args.keep_pre_attr,
     pre_attr=args.pre_attr,

--- a/htmlmin/main.py
+++ b/htmlmin/main.py
@@ -35,6 +35,7 @@ def minify(input,
            remove_empty_space=False,
            remove_all_empty_space=False,
            reduce_boolean_attributes=False,
+           remove_optional_attribute_quotes=True,
            keep_pre=False,
            pre_tags=parser.PRE_TAGS,
            pre_attr='pre'):
@@ -73,7 +74,7 @@ def minify(input,
     free to change this list as you see fit, but you will probably want to
     include ``pre`` and ``textarea`` if you make any changes to the list. Note
     that ``<script>`` and ``<style>`` tags are never minimized.
-  :param pre_attr: Specifies the attribute that, when found in an HTML tag, 
+  :param pre_attr: Specifies the attribute that, when found in an HTML tag,
     indicates that the content of the tag should not be minified. Defaults to
     ``pre``.
   :return: A string containing the minified HTML.
@@ -86,6 +87,7 @@ def minify(input,
       remove_empty_space=remove_empty_space,
       remove_all_empty_space=remove_all_empty_space,
       reduce_boolean_attributes=reduce_boolean_attributes,
+      remove_optional_attribute_quotes=remove_optional_attribute_quotes,
       keep_pre=keep_pre,
       pre_tags=pre_tags,
       pre_attr=pre_attr)
@@ -96,7 +98,7 @@ def minify(input,
 class Minifier(object):
   """An object that supports HTML Minification.
 
-  Options are passed into this class at initialization time and are then 
+  Options are passed into this class at initialization time and are then
   persisted across each use of the instance. If you are going to be minifying
   multiple peices of HTML, this will be more efficient than using
   :class:`htmlmin.minify`.
@@ -109,6 +111,7 @@ class Minifier(object):
                remove_empty_space=False,
                remove_all_empty_space=False,
                reduce_boolean_attributes=False,
+               remove_optional_attribute_quotes=True,
                keep_pre=False,
                pre_tags=parser.PRE_TAGS,
                pre_attr='pre'):
@@ -121,6 +124,7 @@ class Minifier(object):
       remove_empty_space=remove_empty_space,
       remove_all_empty_space=remove_all_empty_space,
       reduce_boolean_attributes=reduce_boolean_attributes,
+      remove_optional_attribute_quotes=remove_optional_attribute_quotes,
       keep_pre=keep_pre,
       pre_tags=pre_tags,
       pre_attr=pre_attr)
@@ -162,7 +166,7 @@ class Minifier(object):
   def finalize(self):
     """Finishes current input HTML and returns mininified result.
 
-    This method flushes any remaining input HTML and returns the minified 
+    This method flushes any remaining input HTML and returns the minified
     result. It resets the state of the internal parser in the process so that
     new HTML can be minified. Be sure to call this method before you reuse
     the ``Minifier`` instance on a new HTML document.

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -105,6 +105,10 @@ FEATURES_TEXTS = {
     '<body> this text should <!--! not --> have comments removed</body>',
     '<body> this text should <!-- not --> have comments removed</body>',
   ),
+  'keep_optional_attribute_quotes': (
+    '<img width="100" height="50" src="#something" />',
+    '<img width="100" height="50" src="#something">',
+  ),
   'keep_pre_attribute': (
     '<body>the <strong pre   style="">pre</strong> should stay  </body>',
     '<body>the <strong pre style>pre</strong> should stay </body>',
@@ -326,6 +330,10 @@ class TestMinifyFeatures(HTMLMinTestCase):
     text = self.__reference_texts__['keep_comments']
     self.assertEqual(htmlmin.minify(text[0], remove_comments=True), text[1])
 
+  def test_keep_optional_attribute_quotes(self):
+    text = self.__reference_texts__['keep_optional_attribute_quotes']
+    self.assertEqual(htmlmin.minify(text[0], remove_optional_attribute_quotes=False), text[1])
+
   def test_keep_pre_attribute(self):
     text = self.__reference_texts__['keep_pre_attribute']
     self.assertEqual(htmlmin.minify(text[0], keep_pre=True), text[1])
@@ -344,7 +352,7 @@ class TestMinifyFeatures(HTMLMinTestCase):
 
   def test_remove_all_empty(self):
     text = self.__reference_texts__['remove_all_empty']
-    self.assertEqual(htmlmin.minify(text[0], remove_all_empty_space=True), 
+    self.assertEqual(htmlmin.minify(text[0], remove_all_empty_space=True),
                      text[1])
 
   def test_dont_minify_div(self):
@@ -401,28 +409,28 @@ class TestMiddleware(HTMLMinTestCase):
       response_headers.append(headers)
     response_body = ''.join(app({'status': status,
                                  'content': content,
-                                 'headers': headers}, 
+                                 'headers': headers},
                                 start_response))
     return response_status[0], response_headers[0], response_body
 
   def test_middlware(self):
     app = HTMLMinMiddleware(self.wsgi_app)
     status, headers, body = self.call_app(
-      app, '200 OK', (('Content-Type', 'text/html'),), 
+      app, '200 OK', (('Content-Type', 'text/html'),),
       '    X    Y   ')
     self.assertEqual(body, ' X Y ')
 
   def test_middlware_minifier_options(self):
     app = HTMLMinMiddleware(self.wsgi_app, remove_comments=True)
     status, headers, body = self.call_app(
-      app, '200 OK', (('Content-Type', 'text/html'),), 
+      app, '200 OK', (('Content-Type', 'text/html'),),
       '    X    Y   <!-- Z -->')
     self.assertEqual(body, ' X Y ')
 
   def test_middlware_off_by_default(self):
     app = HTMLMinMiddleware(self.wsgi_app, by_default=False)
     status, headers, body = self.call_app(
-      app, '200 OK', (('Content-Type', 'text/html'),), 
+      app, '200 OK', (('Content-Type', 'text/html'),),
       '    X    Y   ')
     self.assertEqual(body, '    X    Y   ')
 
@@ -432,7 +440,7 @@ class TestMiddleware(HTMLMinTestCase):
       app, '200 OK', (
         ('Content-Type', 'text/html'),
         ('X-HTML-Min-Enable', 'True'),
-        ), 
+        ),
       '    X    Y   ')
     self.assertEqual(body, ' X Y ')
 
@@ -442,7 +450,7 @@ class TestMiddleware(HTMLMinTestCase):
       app, '200 OK', (
         ('Content-Type', 'text/html'),
         ('X-HTML-Min-Enable', 'False'),
-        ), 
+        ),
       '    X    Y   ')
     self.assertEqual(body, '    X    Y   ')
 
@@ -452,7 +460,7 @@ class TestMiddleware(HTMLMinTestCase):
       app, '200 OK', (
         ('Content-Type', 'text/html'),
         ('X-HTML-Min-Enable', 'False'),
-        ), 
+        ),
       '    X    Y   ')
     self.assertFalse(any((h == 'X-HTML-Min-Enable' for h, v in headers)))
 
@@ -462,7 +470,7 @@ class TestMiddleware(HTMLMinTestCase):
       app, '200 OK', [
         ('Content-Type', 'text/html'),
         ('X-HTML-Min-Enable', 'False'),
-        ], 
+        ],
       '    X    Y   ')
     self.assertTrue(any((h == 'X-HTML-Min-Enable' for h, v in headers)))
 


### PR DESCRIPTION
I am currently in a situation where I'm minifying html snippets where we use placeholders in attributes which get replaced later on. Because the quotes are optional based on the content of the attribute, which isn't yet known when minifying, the quotes are removed when they shouldn't be. I've added an extra option to disable the removing of quotes completely. 

PS: I just noticed my editor removed some trailing whitespace, which ads some noise to the commit. I hope this isn't a problem.
