### PR TITLE
Disallow removing attribute quotes when equal sign is present.

### DIFF
--- a/htmlmin/parser.py
+++ b/htmlmin/parser.py
@@ -121,7 +121,7 @@ class HTMLMinParser(HTMLParser):
              k in BOOLEAN_ATTRIBUTES.get(tag,[]) or
              k in BOOLEAN_ATTRIBUTES['*']):
           pass
-        elif self.remove_optional_attribute_quotes and not any((c in v for c in ('"', "'", ' ', '<', '>'))):
+        elif self.remove_optional_attribute_quotes and not any((c in v for c in ('"', "'", ' ', '<', '>', '='))):
           result += '={}'.format(escape(v, quote=True))
         else:
           result += '="{}"'.format(escape(v, quote=True).replace('&#x27;', "'"))

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -299,14 +299,14 @@ class TestMinifyFunction(HTMLMinTestCase):
     with codecs.open('htmlmin/tests/large_test.html', encoding='utf-8') as inpf:
       inp = inpf.read()
     out = self.minify(inp)
-    self.assertEqual(len(inp) - len(out), 8806)
+    self.assertEqual(len(inp) - len(out), 8610)
 
   def test_high_minification_quality(self):
     import codecs
     with codecs.open('htmlmin/tests/large_test.html', encoding='utf-8') as inpf:
       inp = inpf.read()
     out = self.minify(inp, remove_all_empty_space=True, remove_comments=True)
-    self.assertEqual(len(inp) - len(out), 12043)
+    self.assertEqual(len(inp) - len(out), 11847)
 
 class TestMinifierObject(HTMLMinTestCase):
   __reference_texts__ = MINIFY_FUNCTION_TEXTS


### PR DESCRIPTION
"<tag attr=someval=3>" is not allowed and should be quoted in HTML.
Should remain:
"<tag attr='someval=3'>"
