### PR TITLE
add escape_tags option to enable/disable escaping tag names and attributes

### DIFF
--- a/htmlmin/main.py
+++ b/htmlmin/main.py
@@ -37,6 +37,7 @@ def minify(input,
            reduce_empty_attributes=True,
            reduce_boolean_attributes=False,
            remove_optional_attribute_quotes=True,
+           escape_tags=True,
            keep_pre=False,
            pre_tags=parser.PRE_TAGS,
            pre_attr='pre'):
@@ -93,6 +94,7 @@ def minify(input,
       reduce_empty_attributes=reduce_empty_attributes,
       reduce_boolean_attributes=reduce_boolean_attributes,
       remove_optional_attribute_quotes=remove_optional_attribute_quotes,
+      escape_tags=escape_tags,
       keep_pre=keep_pre,
       pre_tags=pre_tags,
       pre_attr=pre_attr)
@@ -118,6 +120,7 @@ class Minifier(object):
                reduce_empty_attributes=True,
                reduce_boolean_attributes=False,
                remove_optional_attribute_quotes=True,
+               escape_tags=True,
                keep_pre=False,
                pre_tags=parser.PRE_TAGS,
                pre_attr='pre'):
@@ -132,6 +135,7 @@ class Minifier(object):
       reduce_empty_attributes=reduce_empty_attributes,
       reduce_boolean_attributes=reduce_boolean_attributes,
       remove_optional_attribute_quotes=remove_optional_attribute_quotes,
+      escape_tags=escape_tags,
       keep_pre=keep_pre,
       pre_tags=pre_tags,
       pre_attr=pre_attr)

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -69,6 +69,14 @@ test command runs project's unit tests without actually deploying it, by
 }
 
 FEATURES_TEXTS = {
+  'escape_tags_true': (
+    '<body  >  <a href="http://example.com/?hello=world&foo=bar" >hello</a></  body>  ',
+    '<body> <a href="http://example.com/?hello=world&amp;foo=bar">hello</a></body> ',
+  ),
+  'escape_tags_false': (
+    '<body  >  <a href="http://example.com/?hello=world&foo=bar" >hello</a></  body>  ',
+    '<body> <a href="http://example.com/?hello=world&foo=bar">hello</a></body> ',
+  ),
   'remove_quotes': (
     '<body  >  <div id="x" style="   abc " data-a=b></div></  body>  ',
     '<body> <div id=x style="   abc " data-a=b></div></body> ',
@@ -329,6 +337,14 @@ class TestMinifierObject(HTMLMinTestCase):
 
 class TestMinifyFeatures(HTMLMinTestCase):
   __reference_texts__ = FEATURES_TEXTS
+
+  def test_escape_tags_true(self):
+    text = self.__reference_texts__['escape_tags_true']
+    self.assertEqual(htmlmin.minify(text[0], escape_tags=True), text[1])
+
+  def test_escape_tags_false(self):
+    text = self.__reference_texts__['escape_tags_false']
+    self.assertEqual(htmlmin.minify(text[0], escape_tags=False), text[1])
 
   def test_remove_comments(self):
     text = self.__reference_texts__['remove_comments']


### PR DESCRIPTION
```htmlmin``` mangles correct urls by escaping the ```&``` character.
This patch allows to disable the escaping altogether. 

Being a minifier this should probably have been the default. We don't protect or try to correct the user for other html 'errors' like in #4 or escape the ```&``` character when being used inside of a tag.

On a side note; the use of escape() in some places like the name of a tag and the name of an attribute seems to be invalid anyways since it produces broken html. Surely the html was broken to begin with but it does not make sense to change broken html to new also broken html.

Examples:
```
# href value getting incorrectly escaped
In [3]: htmlmin.minify('<a href="http://example.com/?a=1&b=2">link</a>')
Out[3]: u'<a href="http://example.com/?a=1&amp;b=2">link</a>'

# & is not escaped inside a tag
In [4]: htmlmin.minify('<a href="http://example.com/?a=1&b=2">link & click</a>')
Out[4]: u'<a href="http://example.com/?a=1&amp;b=2">link & click</a>'

# escaping tag attribute names produces broken html
In [5]: htmlmin.minify('<a hr&ef="http://example.com/?a=1&b=2">link & click</a>')
Out[5]: u'<a hr&amp;ef="http://example.com/?a=1&amp;b=2">link & click</a>'

# escaping tag names produces broken html
In [6]: htmlmin.minify('<di<v></div>')
Out[6]: u'<di&lt;v></div>'

# escape_tags=False allows to minify without changing the value inside the href attribute
In [7]: htmlmin.minify('<a href="http://example.com/?a=1&b=2">link & click</a>', escape_tags=False)
Out[7]: u'<a href="http://example.com/?a=1&b=2">link & click</a>'
```
