### PR TITLE
Add tox.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 _build
 *.egg-info
 dist
+.tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist=py27, py33, py34
+
+[testenv]
+commands=python setup.py test


### PR DESCRIPTION
I have been using `tox` to run the test suite, which will run it against all the Python versions specified.
