### PR TITLE
Use StringIO to build strings more efficiently

### DIFF
--- a/htmlmin/parser.py
+++ b/htmlmin/parser.py
@@ -32,10 +32,7 @@ try:
 except ImportError:
   from cgi import escape
 
-if sys.version_info[0] == 2:
-  from StringIO import StringIO
-else:
-  from io import StringIO
+from io import StringIO
 
 import re
 try:


### PR DESCRIPTION
See this example article for a performance comparison:
    http://www.skymind.com/~ocrow/python_string/

On the test suite, it does not make much of a performance difference, but using this on large HTML files should be a little quicker (and take less memory).  The string concatenation is effectively run at the C level.

**Note:** this pull request is based on my other pull request. Sorry about that, but I didn't want to cause any merge conflicts between the two. This pull request really only adds a56db1fc30d639cb147d1e6fb59a0e260456308a.
