### PR TITLE
Avoid exception caused by empty html comment.

### DIFF
--- a/htmlmin/parser.py
+++ b/htmlmin/parser.py
@@ -265,7 +265,7 @@ class HTMLMinParser(HTMLParser):
     self._data_buffer.append(self.build_tag(tag, attrs, tag not in NO_CLOSE_TAGS))
 
   def handle_comment(self, data):
-    if not self.remove_comments or data[0] == '!':
+    if not self.remove_comments or (data and data[0] == '!'):
       self._data_buffer.append('<!--{}-->'.format(
           data[1:] if data[0] == '!' else data))
 

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -114,7 +114,7 @@ FEATURES_TEXTS = {
     '<body><br><br>   x   </body>',
   ),
   'remove_comments': (
-    '<body> this text should <!-- X --> have comments removed</body>',
+    '<body> this text should <!-- X --> have <!----> comments removed</body>',
     '<body> this text should have comments removed</body>',
   ),
   'keep_comments': (


### PR DESCRIPTION
htmlmin will raise exception when handling `<!---->`, which follows the HTML syntax.
I fixed this bug and added test for it.