### PR TITLE
Optional parameter that allows comments in tag attributes

### DIFF
--- a/htmlmin/__init__.py
+++ b/htmlmin/__init__.py
@@ -27,4 +27,4 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from .main import minify, Minifier
 
-__version__ = '0.1.6'
+__version__ = '0.1.7'

--- a/htmlmin/command.py
+++ b/htmlmin/command.py
@@ -78,6 +78,14 @@ html if you spread two inline tags over two lines. Use with caution.
 '''),
   action='store_true')
 
+parser.add_argument('--allow-comments-in-tag-attributes',
+  help=(
+'''When set, this preserves comments in tag attributes. For example:
+<link href="<!--anchor:static_url-->style.css"/> would get butchered without this param.
+
+'''),
+  action='store_true')
+
 parser.add_argument('--remove-all-empty-space',
   help=(
 '''When set, this removes ALL empty space betwen tags. WARNING: this can and
@@ -145,6 +153,7 @@ def main():
     remove_comments=args.remove_comments,
     remove_empty_space=args.remove_empty_space,
     remove_optional_attribute_quotes=not args.keep_optional_attribute_quotes,
+    comments_in_tag_attributes=args.allow_comments_in_tag_attributes,
     pre_tags=args.pre_tags,
     keep_pre=args.keep_pre_attr,
     pre_attr=args.pre_attr,

--- a/htmlmin/main.py
+++ b/htmlmin/main.py
@@ -37,6 +37,7 @@ def minify(input,
            reduce_empty_attributes=True,
            reduce_boolean_attributes=False,
            remove_optional_attribute_quotes=True,
+           comments_in_tag_attributes=False,
            keep_pre=False,
            pre_tags=parser.PRE_TAGS,
            pre_attr='pre'):
@@ -93,6 +94,7 @@ def minify(input,
       reduce_empty_attributes=reduce_empty_attributes,
       reduce_boolean_attributes=reduce_boolean_attributes,
       remove_optional_attribute_quotes=remove_optional_attribute_quotes,
+      comments_in_tag_attributes=comments_in_tag_attributes,
       keep_pre=keep_pre,
       pre_tags=pre_tags,
       pre_attr=pre_attr)
@@ -118,6 +120,7 @@ class Minifier(object):
                reduce_empty_attributes=True,
                reduce_boolean_attributes=False,
                remove_optional_attribute_quotes=True,
+               comments_in_tag_attributes=False,
                keep_pre=False,
                pre_tags=parser.PRE_TAGS,
                pre_attr='pre'):
@@ -132,6 +135,7 @@ class Minifier(object):
       reduce_empty_attributes=reduce_empty_attributes,
       reduce_boolean_attributes=reduce_boolean_attributes,
       remove_optional_attribute_quotes=remove_optional_attribute_quotes,
+      comments_in_tag_attributes=comments_in_tag_attributes,
       keep_pre=keep_pre,
       pre_tags=pre_tags,
       pre_attr=pre_attr)

--- a/htmlmin/parser.py
+++ b/htmlmin/parser.py
@@ -92,6 +92,7 @@ class HTMLMinParser(HTMLParser):
                reduce_empty_attributes=True,
                reduce_boolean_attributes=False,
                remove_optional_attribute_quotes=True,
+               comments_in_tag_attributes=False,
                keep_pre=False,
                pre_tags=PRE_TAGS,
                pre_attr='pre'):
@@ -104,6 +105,7 @@ class HTMLMinParser(HTMLParser):
     self.reduce_empty_attributes = reduce_empty_attributes
     self.reduce_boolean_attributes = reduce_boolean_attributes
     self.remove_optional_attribute_quotes = remove_optional_attribute_quotes
+    self.comments_in_tag_attributes = comments_in_tag_attributes
     self.pre_attr = pre_attr
     self._data_buffer = []
     self._in_pre_tag = 0
@@ -139,7 +141,10 @@ class HTMLMinParser(HTMLParser):
           needs_closing_space = v.endswith('/')
         else:
           result.write('="')
-          result.write(escape(v, quote=True).replace('&#x27;', "'"))
+          if not self.comments_in_tag_attributes:
+            result.write(escape(v, quote=True).replace('&#x27;', "'"))
+          else:
+            result.write(v)
           result.write('"')
       elif not self.reduce_empty_attributes:
         result.write('=""')


### PR DESCRIPTION
Comments in tag attributes would normally get escaped unless this modifier is active. 