### PR TITLE
Leave quotes around attributes containing =, <, >, and `

### DIFF
--- a/htmlmin/escape.py
+++ b/htmlmin/escape.py
@@ -30,6 +30,8 @@ try:
 except ImportError:
   from cgi import escape
 
+import re
+
 NO_QUOTES = 0
 SINGLE_QUOTE = 1
 DOUBLE_QUOTE = 2
@@ -61,7 +63,7 @@ def escape_attr_value(val, double_quote=False):
   elif "'" in val:
     return (val, DOUBLE_QUOTE)
 
-  if not val or any((c.isspace() for c in val)) or '=' in val:
+  if not val or any((c.isspace() for c in val)) or re.search(r"[=><`]", val):
     return (val, DOUBLE_QUOTE)
   return (val, NO_QUOTES)
 

--- a/htmlmin/escape.py
+++ b/htmlmin/escape.py
@@ -61,7 +61,7 @@ def escape_attr_value(val, double_quote=False):
   elif "'" in val:
     return (val, DOUBLE_QUOTE)
 
-  if not val or any((c.isspace() for c in val)):
+  if not val or any((c.isspace() for c in val)) or '=' in val:
     return (val, DOUBLE_QUOTE)
   return (val, NO_QUOTES)
 

--- a/htmlmin/tests/test_escape.py
+++ b/htmlmin/tests/test_escape.py
@@ -61,6 +61,9 @@ class TestEscapeAttributes(unittest.TestCase):
     self.assertDoubleQuote(" foobar ", " foobar ")
     self.assertDoubleQuote("", "")
 
+  def test_quote_equal(self):
+    self.assertDoubleQuote("width=device-width", "width=device-width")
+
   def test_force_double_quote(self):
     result = escape.escape_attr_value("foobar", double_quote=True)
     self.assertEqual('foobar', result[0])

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -313,14 +313,14 @@ class TestMinifyFunction(HTMLMinTestCase):
     with codecs.open('htmlmin/tests/large_test.html', encoding='utf-8') as inpf:
       inp = inpf.read()
     out = self.minify(inp)
-    self.assertEqual(len(inp) - len(out), 9579)
+    self.assertEqual(len(inp) - len(out), 9383)
 
   def test_high_minification_quality(self):
     import codecs
     with codecs.open('htmlmin/tests/large_test.html', encoding='utf-8') as inpf:
       inp = inpf.read()
     out = self.minify(inp, remove_all_empty_space=True, remove_comments=True)
-    self.assertEqual(len(inp) - len(out), 12693)
+    self.assertEqual(len(inp) - len(out), 12497)
 
 class TestMinifierObject(HTMLMinTestCase):
   __reference_texts__ = MINIFY_FUNCTION_TEXTS


### PR DESCRIPTION
It's invalid HTML otherwise.

Reference: http://www.w3.org/TR/html-markup/syntax.html#attr-value-unquoted

Fixes #33 and #32 
