### PR TITLE
Fix encoding problem with python3

### DIFF
--- a/htmlmin/command.py
+++ b/htmlmin/command.py
@@ -28,7 +28,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
 import codecs
+import locale
 import io
+import sys
 
 #import htmlmin
 from . import Minifier
@@ -132,9 +134,8 @@ tags are always left unmininfied.
   nargs='*',
   default=['pre', 'textarea'])
 parser.add_argument('-e', '--encoding',
-
   help=("Encoding to read and write with. Default 'utf-8'.\n\n"),
-  default='utf-8',
+  default=None,
   )
 
 def main():
@@ -147,19 +148,25 @@ def main():
     keep_pre=args.keep_pre_attr,
     pre_attr=args.pre_attr,
     )
+  default_encoding = args.encoding or 'utf-8'
+
   if args.input_file:
-    inp = codecs.open(args.input_file, encoding=args.encoding)
+    inp = codecs.open(args.input_file, encoding=default_encoding)
   else:
-    inp = io.open(0, encoding=args.encoding)
+    encoding = args.encoding or sys.stdin.encoding \
+      or locale.getpreferredencoding() or default_encoding
+    inp = io.open(sys.stdin.fileno(), encoding=encoding)
 
   for line in inp.readlines():
     minifier.input(line)
 
   if args.output_file:
     codecs.open(
-      args.output_file, 'w', encoding=args.encoding).write(minifier.output)
+      args.output_file, 'w', encoding=default_encoding).write(minifier.output)
   else:
-    io.open(1, 'w', encoding=args.encoding).write(minifier.output)
+    encoding = args.encoding or sys.stdout.encoding \
+      or locale.getpreferredencoding() or default_encoding
+    io.open(sys.stdout.fileno(), 'w', encoding=encoding).write(minifier.output)
 
 if __name__ == '__main__':
   main()

--- a/htmlmin/command.py
+++ b/htmlmin/command.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 Copyright (c) 2013, Dave Mankoff
 All rights reserved.
@@ -24,8 +25,6 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
-
-#!/usr/bin/env python
 
 import argparse
 import codecs
@@ -160,7 +159,7 @@ def main():
     codecs.open(
       args.output_file, 'w', encoding=args.encoding).write(minifier.output)
   else:
-    print(minifier.output)
+    io.open(1, 'w', encoding=args.encoding).write(minifier.output)
 
 if __name__ == '__main__':
   main()

--- a/htmlmin/command.py
+++ b/htmlmin/command.py
@@ -151,7 +151,7 @@ def main():
   if args.input_file:
     inp = codecs.open(args.input_file, encoding=args.encoding)
   else:
-    inp = io.open(0)
+    inp = io.open(0, encoding=args.encoding)
 
   for line in inp.readlines():
     minifier.input(line)

--- a/htmlmin/command.py
+++ b/htmlmin/command.py
@@ -134,7 +134,9 @@ tags are always left unmininfied.
   nargs='*',
   default=['pre', 'textarea'])
 parser.add_argument('-e', '--encoding',
-  help=("Encoding to read and write with. Default 'utf-8'.\n\n"),
+  help=("Encoding to read and write with. Default 'utf-8'."
+        " When reading from stdin, attempts to use the system's"
+        " encoding before defaulting to utf-8.\n\n"),
   default=None,
   )
 

--- a/htmlmin/command.py
+++ b/htmlmin/command.py
@@ -29,8 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
 import codecs
-import locale
-import sys
+import io
 
 #import htmlmin
 from . import Minifier
@@ -152,8 +151,7 @@ def main():
   if args.input_file:
     inp = codecs.open(args.input_file, encoding=args.encoding)
   else:
-    inp = codecs.getreader(
-      sys.stdin.encoding or locale.getpreferredencoding())(sys.stdin)
+    inp = io.open(0)
 
   for line in inp.readlines():
     minifier.input(line)


### PR DESCRIPTION
This fixes my immediate problem, but I'm not sure if it causes problems...

This is the behavior I was seeing:

```
$ echo 'hello' | python3 -m htmlmin.command -s 
Traceback (most recent call last):
  File "/Users/matt/.pyenv/versions/3.4.3/lib/python3.4/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/Users/matt/.pyenv/versions/3.4.3/lib/python3.4/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/private/tmp/htmlmin/htmlmin/command.py", line 168, in <module>
    main()
  File "/private/tmp/htmlmin/htmlmin/command.py", line 158, in main
    for line in inp.readlines():
  File "/Users/matt/.pyenv/versions/3.4.3/lib/python3.4/codecs.py", line 611, in readlines
    data = self.read()
  File "/Users/matt/.pyenv/versions/3.4.3/lib/python3.4/codecs.py", line 493, in read
    data = self.bytebuffer + newdata
TypeError: can't concat bytes to str
```
