### PR TITLE
Better attribute handling and some other minor changes

### DIFF
--- a/htmlmin/escape.py
+++ b/htmlmin/escape.py
@@ -25,6 +25,8 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
+import re
+
 try:
   from html import escape
 except ImportError:
@@ -59,10 +61,9 @@ def escape_attr_value(val, double_quote=False):
       return (val.replace('"', '&#34;'), DOUBLE_QUOTE)
     else:
       return (val, SINGLE_QUOTE)
-  elif "'" in val:
-    return (val, DOUBLE_QUOTE)
 
-  if not val or any((c.isspace() for c in val)):
+  # https://www.w3.org/TR/html5/syntax.html#attributes-0
+  if not val or re.search("['<=>`\0-\40]", val):
     return (val, DOUBLE_QUOTE)
   return (val, NO_QUOTES)
 

--- a/htmlmin/escape.py
+++ b/htmlmin/escape.py
@@ -56,14 +56,21 @@ def escape_attr_value(val, double_quote=False):
   has_html_tag = '<' in val or '>' in val
   if double_quote:
     return (val.replace('"', '&#34;'), DOUBLE_QUOTE)
-  if '"' in val or has_html_tag:
-    if "'" in val or has_html_tag:
-      return (val.replace('"', '&#34;'), DOUBLE_QUOTE)
+
+  dq = sq = 0
+  for ch in val:
+    if ch == '"':
+      dq += 1
+    elif ch == "'":
+      sq += 1
+  if dq or sq:
+    if dq <= sq:
+      return (val.replace('"', '&#%d;' % ord('"')), DOUBLE_QUOTE)
     else:
-      return (val, SINGLE_QUOTE)
+      return (val.replace("'", '&#%d;' % ord("'")), SINGLE_QUOTE)
 
   # https://www.w3.org/TR/html5/syntax.html#attributes-0
-  if not val or re.search("['<=>`\0-\40]", val):
+  if not val or re.search('[<=>`\0-\40]', val):
     return (val, DOUBLE_QUOTE)
   return (val, NO_QUOTES)
 

--- a/htmlmin/main.py
+++ b/htmlmin/main.py
@@ -39,7 +39,8 @@ def minify(input,
            remove_optional_attribute_quotes=True,
            keep_pre=False,
            pre_tags=parser.PRE_TAGS,
-           pre_attr='pre'):
+           pre_attr='pre',
+           cls=parser.HTMLMinParser):
   """Minifies HTML in one shot.
 
   :param input: A string containing the HTML to be minified.
@@ -85,7 +86,7 @@ def minify(input,
   If you are going to be minifying multiple HTML documents, each with the same
   settings, consider using :class:`.Minifier`.
   """
-  minifier = parser.HTMLMinParser(
+  minifier = cls(
       remove_comments=remove_comments,
       remove_empty_space=remove_empty_space,
       remove_all_empty_space=remove_all_empty_space,
@@ -119,12 +120,13 @@ class Minifier(object):
                remove_optional_attribute_quotes=True,
                keep_pre=False,
                pre_tags=parser.PRE_TAGS,
-               pre_attr='pre'):
+               pre_attr='pre',
+               cls=parser.HTMLMinParser):
     """Initialize the Minifier.
 
     See :class:`htmlmin.minify` for an explanation of options.
     """
-    self._parser = parser.HTMLMinParser(
+    self._parser = cls(
       remove_comments=remove_comments,
       remove_empty_space=remove_empty_space,
       remove_all_empty_space=remove_all_empty_space,
@@ -181,4 +183,3 @@ class Minifier(object):
     result = self._parser.result
     self._parser.reset()
     return result
-

--- a/htmlmin/parser.py
+++ b/htmlmin/parser.py
@@ -134,7 +134,8 @@ class HTMLMinParser(HTMLParser):
     attrs = list(attrs)  # We're modifying it in place
     for i, (k, v) in enumerate(attrs):
       k = escape.escape_attr_name(k)
-      if (not v and self.reduce_empty_attributes) or reduce_boolean(k):
+      if (v is None or (not v and self.reduce_empty_attributes) or
+          reduce_boolean(k)):
         # For our use case, we treat boolean attributes as quoted because they
         # don't require space between them and "/>" in closing tags.
         attrs[i] = k

--- a/htmlmin/parser.py
+++ b/htmlmin/parser.py
@@ -114,9 +114,8 @@ class HTMLMinParser(HTMLParser):
 
     if self.reduce_boolean_attributes:
       bool_attrs = (BOOLEAN_ATTRIBUTES.get(tag, ()), BOOLEAN_ATTRIBUTES['*'])
-      reduce_boolean = lambda k: k in bool_attrs[0] or k in bool_attrs[1]
     else:
-      reduce_boolean = lambda k: False
+      bool_attrs = False
 
     attrs = list(attrs)  # We're modifying it in place
     last_quoted = last_no_slash = i = -1
@@ -129,7 +128,7 @@ class HTMLMinParser(HTMLParser):
       i += 1
       k = escape.escape_attr_name(k)
       if (v is None or (not v and self.reduce_empty_attributes) or
-          reduce_boolean(k)):
+          (bool_attrs and (k in bool_attrs[0] or k in bool_attrs[1]))):
         # For our use case, we treat boolean attributes as quoted because they
         # don't require space between them and "/>" in closing tags.
         attrs[i] = k

--- a/htmlmin/parser.py
+++ b/htmlmin/parser.py
@@ -184,7 +184,7 @@ class HTMLMinParser(HTMLParser):
     if (len(self._data_buffer) == 1 and
         whitespace_re.match(self._data_buffer[0])):
       self._data_buffer = []
-    self._data_buffer.append('<!' + decl + '>\n')
+    self._data_buffer.append('<!' + decl + '>')
     self._after_doctype = True
 
   def in_tag(self, *tags):

--- a/htmlmin/tests/test_escape.py
+++ b/htmlmin/tests/test_escape.py
@@ -33,8 +33,7 @@ from htmlmin import escape
 class TestEscapeAttributes(unittest.TestCase):
   def assertQuotes(self, value, expected, quotes):
     result = escape.escape_attr_value(value)
-    self.assertEqual(expected, result[0])
-    self.assertEqual(quotes, result[1])
+    self.assertEqual((expected, quotes), result)
 
   def assertNoQuotes(self, value, expected):
     self.assertQuotes(value, expected, escape.NO_QUOTES)
@@ -60,6 +59,11 @@ class TestEscapeAttributes(unittest.TestCase):
     self.assertDoubleQuote("foobar ", "foobar ")
     self.assertDoubleQuote(" foobar ", " foobar ")
     self.assertDoubleQuote("", "")
+
+  def test_quote_special_characters(self):
+    for ch in "'<>`= ":
+      self.assertDoubleQuote("foo%sbar" % ch, "foo%sbar" % ch)
+    self.assertSingleQuote("foo\"bar", "foo\"bar")
 
   def test_force_double_quote(self):
     result = escape.escape_attr_value("foobar", double_quote=True)

--- a/htmlmin/tests/test_escape.py
+++ b/htmlmin/tests/test_escape.py
@@ -72,6 +72,8 @@ class TestEscapeAttributes(unittest.TestCase):
 
   def test_both_quotes(self):
     self.assertDoubleQuote("foo'\"bar", "foo'&#34;bar")
+    self.assertDoubleQuote("foo''\"bar", "foo''&#34;bar")
+    self.assertSingleQuote("foo'\"\"bar", 'foo&#39;""bar')
 
   def test_ampersand_char_ref(self):
     self.assertNoQuotes('foo&bar', 'foo&amp;bar')

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -75,9 +75,15 @@ FEATURES_TEXTS = {
     '<body  >  <div id="x" style="   abc " data-a=b></div></  body>  ',
     '<body> <div id=x style="   abc " data-a=b></div></body> ',
   ),
-  'remove_quotes_keep_quote_trailing_slash_last': (
+  'remove_quotes_drop_trailing_slash': (
     '<div x="x/" y="y/"></div>',
-    '<div x=x/ y=y/ ></div>',  # NOTE the single space at the end, inserted to not make this a self-closing tag
+    # Note: According to https://github.com/mankyd/htmlmin/pull/12 older version
+    # of WebKit would erroneously interpret "<... y=y/>" as self-closing tag.
+    '<div x=x/ y=y/ ></div>',
+  ),
+  'remove_quotes_keep_space_before_slash': (
+    '<foo x="x/"/>',
+    '<foo x=x/ />',  # NOTE: Space added so self-closing tag is parsed as such.
   ),
   'remove_single_quotes': (
     '<body><div thing=\'what\'></div></body> ',
@@ -327,14 +333,14 @@ class TestMinifyFunction(HTMLMinTestCase):
     with codecs.open('htmlmin/tests/large_test.html', encoding='utf-8') as inpf:
       inp = inpf.read()
     out = self.minify(inp)
-    self.assertEqual(len(inp) - len(out), 9579)
+    self.assertEqual(len(inp) - len(out), 9587)
 
   def test_high_minification_quality(self):
     import codecs
     with codecs.open('htmlmin/tests/large_test.html', encoding='utf-8') as inpf:
       inp = inpf.read()
     out = self.minify(inp, remove_all_empty_space=True, remove_comments=True)
-    self.assertEqual(len(inp) - len(out), 12693)
+    self.assertEqual(len(inp) - len(out), 12701)
 
 class TestMinifierObject(HTMLMinTestCase):
   __reference_texts__ = MINIFY_FUNCTION_TEXTS

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -333,14 +333,14 @@ class TestMinifyFunction(HTMLMinTestCase):
     with codecs.open('htmlmin/tests/large_test.html', encoding='utf-8') as inpf:
       inp = inpf.read()
     out = self.minify(inp)
-    self.assertEqual(len(inp) - len(out), 9588)
+    self.assertEqual(len(inp) - len(out), 9392)
 
   def test_high_minification_quality(self):
     import codecs
     with codecs.open('htmlmin/tests/large_test.html', encoding='utf-8') as inpf:
       inp = inpf.read()
     out = self.minify(inp, remove_all_empty_space=True, remove_comments=True)
-    self.assertEqual(len(inp) - len(out), 12702)
+    self.assertEqual(len(inp) - len(out), 12506)
 
 class TestMinifierObject(HTMLMinTestCase):
   __reference_texts__ = MINIFY_FUNCTION_TEXTS

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -66,7 +66,7 @@ test command runs project's unit tests without actually deploying it, by
   ),
   'with_doctype': (
     '\n\n<!DOCTYPE html>\n\n<body>   X   Y   </body>',
-    '<!DOCTYPE html>\n<body> X Y </body>'
+    '<!DOCTYPE html><body> X Y </body>'
   ),
 }
 
@@ -333,14 +333,14 @@ class TestMinifyFunction(HTMLMinTestCase):
     with codecs.open('htmlmin/tests/large_test.html', encoding='utf-8') as inpf:
       inp = inpf.read()
     out = self.minify(inp)
-    self.assertEqual(len(inp) - len(out), 9587)
+    self.assertEqual(len(inp) - len(out), 9588)
 
   def test_high_minification_quality(self):
     import codecs
     with codecs.open('htmlmin/tests/large_test.html', encoding='utf-8') as inpf:
       inp = inpf.read()
     out = self.minify(inp, remove_all_empty_space=True, remove_comments=True)
-    self.assertEqual(len(inp) - len(out), 12701)
+    self.assertEqual(len(inp) - len(out), 12702)
 
 class TestMinifierObject(HTMLMinTestCase):
   __reference_texts__ = MINIFY_FUNCTION_TEXTS

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -207,6 +207,12 @@ FEATURES_TEXTS = {
     '<body>    <y />   <x    /></body>',
     '<body> <y/> <x/></body>',
   ),
+  'remove_redundant_lang_0': (
+    ('<html><body lang=en><p lang=en>This is an example.'
+     '<p lang=pl>I po polsku <span lang=el>and more English</span>.'),
+    ('<html><body lang=en><p>This is an example.'
+     '<p lang=pl>I po polsku <span lang=el>and more English</span>.'),
+  ),
 }
 
 SELF_CLOSE_TEXTS = {
@@ -333,14 +339,14 @@ class TestMinifyFunction(HTMLMinTestCase):
     with codecs.open('htmlmin/tests/large_test.html', encoding='utf-8') as inpf:
       inp = inpf.read()
     out = self.minify(inp)
-    self.assertEqual(len(inp) - len(out), 9392)
+    self.assertEqual(len(inp) - len(out), 9408)
 
   def test_high_minification_quality(self):
     import codecs
     with codecs.open('htmlmin/tests/large_test.html', encoding='utf-8') as inpf:
       inp = inpf.read()
     out = self.minify(inp, remove_all_empty_space=True, remove_comments=True)
-    self.assertEqual(len(inp) - len(out), 12506)
+    self.assertEqual(len(inp) - len(out), 12522)
 
 class TestMinifierObject(HTMLMinTestCase):
   __reference_texts__ = MINIFY_FUNCTION_TEXTS


### PR DESCRIPTION
1. Most importantly, reorder attributes to avoid spaces.
2. There’s no need for \n after <!DOCTYPE…>.
3. Never turn boolean attributes into attributes with empty value.
4. Add cls attribute so it’s easier to extend HTMLMinParser.
5. Some refactoring to use io.StringIO rather than a list.
