### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,4 +3,4 @@ A configurable HTML Minifier with safety features.
 .. image:: https://travis-ci.org/mankyd/htmlmin.png?branch=master
    :target: http://travis-ci.org/mankyd/htmlmin
 
-Documentation: https://htmlmin.readthedocs.org/en/latest/
+Documentation: https://htmlmin.readthedocs.io/en/latest/

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license='BSD',
     description='An HTML Minifier',
     long_description=README,
-    url='https://htmlmin.readthedocs.org/en/latest/',
+    url='https://htmlmin.readthedocs.io/en/latest/',
     download_url='https://github.com/mankyd/htmlmin',
     author='Dave Mankoff',
     author_email='mankyd@gmail.com',


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
