### PR TITLE
Fixed index out of range error when comment is empty

### DIFF
--- a/htmlmin/parser.py
+++ b/htmlmin/parser.py
@@ -278,7 +278,7 @@ class HTMLMinParser(HTMLParser):
     if not self.remove_comments or (
         data and (data[0] == '!' or re.match(r'^\[if\s', data))):
       self._data_buffer.append('<!--{}-->'.format(
-          data[1:] if data[0] == '!' else data))
+          data[1:] if len(data) and data[0] == '!' else data))
 
   def handle_data(self, data):
     if self._in_pre_tag > 0:

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -123,6 +123,10 @@ FEATURES_TEXTS = {
     '<body> this text should <!--! not --> have comments removed</body>',
     '<body> this text should <!-- not --> have comments removed</body>',
   ),
+  'keep_empty_comments': (
+    '<body> this text should not<!----> have empty comments removed</body>',
+    '<body> this text should not<!----> have empty comments removed</body>',
+  ),
   'keep_conditional_comments': (
     '<body>keep IE conditional styles <!--[if IE8]><style>h1 {color: red;}</style><![endif]--></body>',
     '<body>keep IE conditional styles <!--[if IE8]><style>h1 {color: red;}</style><![endif]--></body>',
@@ -367,6 +371,10 @@ class TestMinifyFeatures(HTMLMinTestCase):
   def test_keep_comments(self):
     text = self.__reference_texts__['keep_comments']
     self.assertEqual(htmlmin.minify(text[0], remove_comments=True), text[1])
+
+  def test_keep_empty_comments(self):
+    text = self.__reference_texts__['keep_empty_comments']
+    self.assertEqual(htmlmin.minify(text[0]), text[1])
 
   def test_keep_conditional_comments(self):
     text = self.__reference_texts__['keep_conditional_comments']


### PR DESCRIPTION
IndexError appears, when html comment is empty (ex. ```<!---->```)
