### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,8 +34,8 @@ When we say that htmlmin has 'seatbelts', what we mean is that it comes with
 features that you can use to safely minify beyond the defaults, but you have to
 put them in yourself. For instance, by default, htmlmin will never minimize the
 content between ``<pre>``, ``<textarea>``, ``<script>``, and ``<style>`` tags.
-You can also  explicitly tell it to not minify additional tags either globally 
-by name or by adding the custom ``pre`` attribute to a tag in your HTML. htmlmin 
+You can also  explicitly tell it to not minify additional tags either globally
+by name or by adding the custom ``pre`` attribute to a tag in your HTML. htmlmin
 will remove the ``pre`` attributes as it parses your HTML automatically.
 
 It also includes a command-line tool for easy invocation and integration with
@@ -46,7 +46,7 @@ Install
 
 To install via pip::
 
-  pip install htmlmin 
+  pip install htmlmin
 
 Source Code
 ===========
@@ -69,7 +69,7 @@ Features
   function output.
 * Simple :class:`WSGI middleware <htmlmin.middleware.HTMLMinMiddleware>` to
   minify web app output.
-* `Tested <https://travis-ci.org/mankyd/htmlmin>`_ in both Python 2.7 and 3.2: 
+* `Tested <https://travis-ci.org/mankyd/htmlmin>`_ in both Python 2.7 and 3.2:
   |build_status|
 
 .. |build_status| image:: https://travis-ci.org/mankyd/htmlmin.png?branch=master

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -30,7 +30,7 @@ tag alone and will remove the ``pre`` attribute before it is output::
   >>> htmlmin.minify(input_html)
   u'<span> minified </span><span>   not minified   </span>'
 
-Attributes will be condensed to their smallest possible representation by 
+Attributes will be condensed to their smallest possible representation by
 default. You can prefix an individual attribute with ``pre-`` to leave it
 unchanged::
 
@@ -78,15 +78,15 @@ any time by running `htmlmin -h`::
                           put two of them: <!--!! comment -->.
 
     -s, --remove-empty-space
-                          When set, this removes empty space betwen tags in certain cases. 
+                          When set, this removes empty space betwen tags in certain cases.
                           Specifically, it will remove empty space if and only if there a newline
-                          character occurs within the space. Thus, code like 
+                          character occurs within the space. Thus, code like
                           '<span>x</span> <span>y</span>' will be left alone, but code such as
                           '   ...
                             </head>
                             <body>
                               ...'
-                          will become '...</head><body>...'. Note that this CAN break your 
+                          will become '...</head><body>...'. Note that this CAN break your
                           html if you spread two inline tags over two lines. Use with caution.
 
     --remove-all-empty-space
@@ -107,7 +107,7 @@ any time by running `htmlmin -h`::
                           keep the 'pre' attributes in place.
 
     -a PRE_ATTR, --pre-attr PRE_ATTR
-                          The attribute htmlmin looks for to find blocks of HTML that it should not 
+                          The attribute htmlmin looks for to find blocks of HTML that it should not
                           minify. This attribute will be removed from the HTML unless '-k' is
                           specified. Defaults to 'pre'. You can also prefix individual tag attributes
                           with ``{pre_attr}-`` to prevent the contents of the individual attribute from

--- a/htmlmin/command.py
+++ b/htmlmin/command.py
@@ -172,4 +172,3 @@ def main():
 
 if __name__ == '__main__':
   main()
-

--- a/htmlmin/decorator.py
+++ b/htmlmin/decorator.py
@@ -61,4 +61,3 @@ def htmlmin(*args, **kwargs):
       'htmlmin decorator does accept positional arguments')
   else:
     return _decorator
-        

--- a/htmlmin/main.py
+++ b/htmlmin/main.py
@@ -83,7 +83,7 @@ def minify(input,
     that ``<script>`` and ``<style>`` tags are never minimized.
   :param pre_attr: Specifies the attribute that, when found in an HTML tag,
     indicates that the content of the tag should not be minified. Defaults to
-    ``pre``. You can also prefix individual tag attributes with 
+    ``pre``. You can also prefix individual tag attributes with
     ``{pre_attr}-`` to prevent the contents of the individual attribute from
     being changed.
   :return: A string containing the minified HTML.

--- a/htmlmin/middleware.py
+++ b/htmlmin/middleware.py
@@ -32,10 +32,10 @@ class HTMLMinMiddleware(object):
 
   :param by_default: Specifies if minification should be turned on or off by
     default. Defaults to ``True``.
-  :param keep_header: The middleware recognizes one custom HTTP header that 
+  :param keep_header: The middleware recognizes one custom HTTP header that
     can be used to turn minification on or off on a per-request basis:
     ``X-HTML-Min-Enable``. Setting the header to ``true`` will turn minfication
-    on; anything else will turn minification off. If ``by_default`` is set to 
+    on; anything else will turn minification off. If ``by_default`` is set to
     ``False``, this header is how you would turn minification back on. The
     middleware, by default, removes the header from the output. Setting this
     to ``True`` leaves the header in tact.
@@ -47,14 +47,14 @@ class HTMLMinMiddleware(object):
   passed on to the internal minifier. The documentation for the options can
   be found under :class:`htmlmin.minify`.
   """
-  def __init__(self, app, by_default=True, keep_header=False, 
+  def __init__(self, app, by_default=True, keep_header=False,
                debug=False, **kwargs):
     self.app = app
     self.by_default = by_default
     self.debug = debug
     self.keep_header = keep_header
     self.minifier = Minifier(**kwargs)
-    
+
   def __call__(self, environ, start_response):
     if self.debug:
       return self.app(environ, start_response)
@@ -64,7 +64,7 @@ class HTMLMinMiddleware(object):
     def minified_start_response(status, headers, exc_info=None):
       should_minify.append(self.should_minify(headers))
       if not self.keep_header:
-        headers = [(header, value) for header, value in 
+        headers = [(header, value) for header, value in
                    headers if header != 'X-HTML-Min-Enable']
       start_response(status, headers, exc_info)
 
@@ -72,7 +72,7 @@ class HTMLMinMiddleware(object):
     if should_minify[0]:
       return [self.minifier.minify(*html)]
     return html
-  
+
   def should_minify(self, headers):
     is_html = False
     flag_header = None
@@ -88,5 +88,5 @@ class HTMLMinMiddleware(object):
           break
 
     return is_html and (
-      (self.by_default and flag_header != False) or 
+      (self.by_default and flag_header != False) or
       (not self.by_default and flag_header))

--- a/htmlmin/parser.py
+++ b/htmlmin/parser.py
@@ -233,7 +233,7 @@ class HTMLMinParser(HTMLParser):
                                       '/' if close_tag else ''), lang
 
   def handle_decl(self, decl):
-    if (len(self._data_buffer) == 1 and 
+    if (len(self._data_buffer) == 1 and
         HTML_SPACE_RE.match(self._data_buffer[0][0])):
       self._data_buffer = []
     self._data_buffer.append('<!' + decl + '>')

--- a/htmlmin/python3html/parser.py
+++ b/htmlmin/python3html/parser.py
@@ -5,7 +5,7 @@
 # features. The original file can be found at:
 # https://github.com/python/cpython/blob/44b548dda872c0d4f30afd6b44fd74b053a55ad8/Lib/html/parser.py
 #
-# The largest difference is the reinstatment of the unescape method in 
+# The largest difference is the reinstatment of the unescape method in
 # HTMLParser, which is needed for features in htmlmin. Changes are also
 # made to ensure Python2.7 compatability.
 ########

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -393,7 +393,7 @@ class TestMinifierObject(HTMLMinTestCase):
     self.minifier.input(text[0][len(text[0]) // 2:])
     self.assertEqual(self.minifier.finalize(), text[1])
 
-  
+
 class TestMinifyFeatures(HTMLMinTestCase):
   __reference_texts__ = FEATURES_TEXTS
 


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all
in one go, it helps keep future diffs cleaner by avoiding spurious white
space changes on unrelated lines.