### PR TITLE
Remove unnecessary u prefix

### DIFF
--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -223,7 +223,7 @@ FEATURES_TEXTS = {
   ),
   'convert_charrefs': (
     '<input value="&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;">',
-     u'<input value="&#34;\'\'\'<.\u03c0> &#34;">',
+     '<input value="&#34;\'\'\'<.\u03c0> &#34;">',
   ),
   'convert_charrefs_false': (
     '<input value="&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;">',


### PR DESCRIPTION
The contains 'from __future__ import unicode_literals' so the u-prefix
can be removed.