### PR TITLE
Process character references in data

### DIFF
--- a/htmlmin/main.py
+++ b/htmlmin/main.py
@@ -70,9 +70,9 @@ def minify(input,
   :param remove_optional_attribute_quotes: When True, optional quotes around
     attributes are removed. When False, all attribute quotes are left intact.
     Defaults to True.
-  :param conver_charrefs: Decode character references such as &amp; and &#46;
-    to their single charater values where safe. This currently only applies to
-    attributes. Data content between tags will be left encoded.
+  :param convert_charrefs: Decode character references such as &amp; and &#46;
+    to their single charater values where safe. This applies to attributes as
+    well as data.
   :param keep_pre: By default, htmlmin uses the special attribute ``pre`` to
     allow you to demarcate areas of HTML that should not be minified. It removes
     this attribute as it finds it. Setting this value to ``True`` tells htmlmin
@@ -83,7 +83,7 @@ def minify(input,
     that ``<script>`` and ``<style>`` tags are never minimized.
   :param pre_attr: Specifies the attribute that, when found in an HTML tag,
     indicates that the content of the tag should not be minified. Defaults to
-    ``pre``. You can also prefix individual tag attributes with 
+    ``pre``. You can also prefix individual tag attributes with
     ``{pre_attr}-`` to prevent the contents of the individual attribute from
     being changed.
   :return: A string containing the minified HTML.

--- a/htmlmin/parser.py
+++ b/htmlmin/parser.py
@@ -31,6 +31,7 @@ import sys
 
 import re
 from .python3html.parser import HTMLParser
+from .python3html import unescape as py_unescape
 
 from . import escape
 
@@ -157,7 +158,7 @@ class HTMLMinParser(HTMLParser):
         if not self.keep_pre and not pre_prefix:
           continue
       if v and self.convert_charrefs and not pre_prefix:
-        v = HTMLParser.unescape(self, v)
+        v = py_unescape(v, in_attr=True)
       if k == 'lang':
         lang = v
         if v == self._tag_lang():
@@ -233,7 +234,7 @@ class HTMLMinParser(HTMLParser):
                                       '/' if close_tag else ''), lang
 
   def handle_decl(self, decl):
-    if (len(self._data_buffer) == 1 and 
+    if (len(self._data_buffer) == 1 and
         HTML_SPACE_RE.match(self._data_buffer[0][0])):
       self._data_buffer = []
     self._data_buffer.append('<!' + decl + '>')

--- a/htmlmin/python3html/__init__.py
+++ b/htmlmin/python3html/__init__.py
@@ -103,28 +103,30 @@ def _replace_charref(s):
             num = int(s[2:].rstrip(';'), 16)
         else:
             num = int(s[1:].rstrip(';'))
-        if num in _invalid_charrefs:
-            return _invalid_charrefs[num]
+        v = _invalid_charrefs.get(num)
+        if v is not None:
+            return v
         if 0xD800 <= num <= 0xDFFF or num > 0x10FFFF:
             return '\uFFFD'
         if num in _invalid_codepoints:
             return ''
         return unichr(num)
-    else:
-        # named charref
-        if s in _html5:
-            return _html5[s]
-        # find the longest matching name (as defined by the standard)
-        for x in range(len(s)-1, 1, -1):
-            if s[:x] in _html5:
-                return _html5[s[:x]] + s[x:]
-        else:
-            return '&' + s
+
+    # named charref
+    v = _html5.get(s)
+    if v is not None:
+        return v
+    # find the longest matching name (as defined by the standard)
+    for x in range(len(s)-1, 1, -1):
+        v = _html5.get(s[:x])
+        if v is not None:
+            return v + s[x:]
+    return '&' + s
 
 
 _charref = _re.compile(r'&(#[0-9]+;?'
                        r'|#[xX][0-9a-fA-F]+;?'
-                       r'|[^\t\n\f <&#;]{1,32};?)')
+                       r'|[a-zA-Z][0-9a-zA-Z]{,30};?)')
 
 def unescape(s):
     """

--- a/htmlmin/python3html/__init__.py
+++ b/htmlmin/python3html/__init__.py
@@ -95,7 +95,7 @@ _invalid_codepoints = {
 }
 
 
-def _replace_charref(s):
+def _replace_charref(s, in_attr):
     s = s.group(1)
     if s[0] == '#':
         # numeric charref
@@ -117,10 +117,11 @@ def _replace_charref(s):
     if v is not None:
         return v
     # find the longest matching name (as defined by the standard)
-    for x in range(len(s)-1, 1, -1):
-        v = _html5.get(s[:x])
-        if v is not None:
-            return v + s[x:]
+    if not in_attr:
+        for x in range(len(s)-1, 1, -1):
+            v = _html5.get(s[:x])
+            if v is not None:
+                return v + s[x:]
     return '&' + s
 
 
@@ -128,7 +129,14 @@ _charref = _re.compile(r'&(#[0-9]+;?'
                        r'|#[xX][0-9a-fA-F]+;?'
                        r'|[a-zA-Z][0-9a-zA-Z]{,30};?)')
 
-def unescape(s):
+# Like _charref but requires ; after named reference, see
+# https://html.spec.whatwg.org/multipage/parsing.html#named-character-reference-state
+_charref_in_attr = _re.compile(r'&(#[0-9]+;?'
+                               r'|#[xX][0-9a-fA-F]+;?'
+                               r'|[a-zA-Z][0-9a-zA-Z]{,30};)')
+
+
+def unescape(s, in_attr=False):
     """
     Convert all named and numeric character references (e.g. &gt;, &#62;,
     &x3e;) in the string s to the corresponding unicode characters.
@@ -138,4 +146,5 @@ def unescape(s):
     """
     if '&' not in s:
         return s
-    return _charref.sub(_replace_charref, s)
+    return (_charref_in_attr if in_attr else _charref).sub(
+        lambda m: _replace_charref(m, in_attr), s)

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -199,6 +199,16 @@ FEATURES_TEXTS = {
     '<head>  <title>   &#x2603;X  Y  &amp;  Z </title>  </head>',
     '<head><title>&#x2603;X Y &amp; Z</title></head>',
   ),
+  'pre_respected_on_title': (
+    '<head><title pre> Foo  bar </title></head>',
+    '<head><title> Foo  bar </title></head>',
+  ),
+  # TODO: This is invalid HTML but regardless we should handle it sensibly
+  # rather than removing trailing whitespace everywhere.
+  'missing_title_end': (
+    '<head><title> Test </head><p>Foo <i> bar </i> and baz. </p>',
+    '<head><title>Test</head><p> Foo<i> bar</i> and baz.</p>',
+  ),
   'dont_minify_scripts_or_styles': (
     '<body>  <script>   X  </script>  <style>   X</style>   </body>',
     '<body> <script>   X  </script> <style>   X</style> </body>',
@@ -221,18 +231,74 @@ FEATURES_TEXTS = {
     ('<html><body lang=en><p>This is an example.'
      '<p lang=pl>I po polsku <span lang=el>and more English</span>.'),
   ),
-  'convert_charrefs': (
-    '<input value="&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;">',
-     u'<input value="&#34;\'\'\'<.\u03c0> &#34;">',
-  ),
-  'convert_charrefs_false': (
-    '<input value="&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;">',
-    '<input value="&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;">',
-  ),
   'dont_convert_pre_attr': (
     '<input pre-value="&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;">',
     '<input value=&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;>',
   ),
+  'remove_entity_space': (
+    '<p>Foo &#x20; bar &#32; baz</p>',
+    '<p>Foo &#x20; bar &#32; baz</p>',
+  ),
+  # TODO: Fix, this should generate &amp;amp;
+  'escape_after_close_tag_removal': (
+    '<p><br>Foo &</br>amp; bar, <br>baz &am</br>p; qux</p>',
+    '<p><br>Foo &amp; bar, <br>baz &amp; qux</p>',
+  ),
+  # Note: the ‘]’ being eaten is Python bug in _markupbase.py, see
+  # https://github.com/python/cpython/pull/24720
+  'leave_cdata_alone': (
+    '<p>Leave <![CDATA[ & &#38; &amp;  < &lt;  ]]> alone.',
+    '<p>Leave <![CDATA[ & &#38; &amp;  < &lt;  ]> alone.',
+  ),
+}
+
+# key: (input, out_attribute_on, out_attribute_off, out_text_on, out_text_off)
+CONVERT_CHARREFS_TEXTS = {
+  'entities': (
+    '&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;',
+    u'&#34;\'\'\'<.\u03C0> &#34;',
+    '&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;',
+    '&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;',
+    '&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;',
+  ),
+  'not_escaped': (
+    'Tiffany &amp; Co. H&M 1&amp;2 1&amp;2;',
+    'Tiffany & Co. H&M 1&2 1&2;',
+    'Tiffany &amp; Co. H&M 1&amp;2 1&amp;2;',
+    'Tiffany &amp; Co. H&M 1&amp;2 1&amp;2;',
+    # TODO: Fix.  There is no named character reference ‘M’ and as such ‘&M’ is
+    # perfectly valid way to write ‘&M’ according to HTML5.  Changing it to
+    # ‘&M;’ changes the text.  This is probably Python bug.
+    'Tiffany &amp; Co. H&M; 1&amp;2 1&amp;2;',
+  ),
+  'at_end': (
+    ' 1&amp;2',
+    ' 1&amp;2',
+    ' 1&amp;2',
+    ' 1&amp;2',
+    ' 1&amp;2',
+  ),
+  'no_semicolon': (
+    '/?sect=2&para=5&par=8',
+    # TODO: Fix.  Inside of an attribute value, if named character reference
+    # does not end with a semicolon and is proceeded by an equal sign, it must
+    # be left intact.
+    u'/?sect=2\u00B6=5&par=8',
+    '/?sect=2&para=5&par=8',
+    '/?sect=2&para=5&par=8',
+    # TODO: Fix.  There is no named character reference ‘par’ (even though
+    # there’s ‘par;’) and as such ‘&par’ is perfectly valid way to write ‘&par’
+    # according to HTML5.  Changing it to ‘&par;’ changes the text.  This is
+    # probably Python bug.
+    '/?sect=2&para;=5&par;=8',
+  ),
+  'followed_by_eq': (
+    '/?sect=2&amp;para=5',
+    '/?sect=2&para=5',
+    '/?sect=2&amp;para=5',
+    '/?sect=2&amp;para=5',
+    '/?sect=2&amp;para=5',
+  )
 }
 
 SELF_CLOSE_TEXTS = {
@@ -334,16 +400,14 @@ SELF_OPENING_TEXTS = {
   ),
 }
 
+def _make_test(inp, out, **kw):
+  return lambda self: self.assertEqual(self.minify(inp, **kw), out)
+
 class HTMLMinTestMeta(type):
   def __new__(cls, name, bases, dct):
-    def make_test(text):
-      def inner_test(self):
-        self.assertEqual(self.minify(text[0]), text[1])
-      return inner_test
-
     for k, v in dct.get('__reference_texts__',{}).items():
       if 'test_'+k not in dct:
-        dct['test_'+k] = make_test(v)
+        dct['test_'+k] = _make_test(*v)
     return type.__new__(cls, str(name), bases, dct)
 
 class HTMLMinTestCase(
@@ -354,19 +418,28 @@ class HTMLMinTestCase(
 class TestMinifyFunction(HTMLMinTestCase):
   __reference_texts__ = MINIFY_FUNCTION_TEXTS
 
-  def test_basic_minification_quality(self):
+  def _test_minification_quality(self, want_chars, want_bytes, *args, **kw):
     import codecs
     with codecs.open('htmlmin/tests/large_test.html', encoding='utf-8') as inpf:
       inp = inpf.read()
-    out = self.minify(inp)
-    self.assertEqual(len(inp) - len(out), 9408)
+    out = self.minify(inp, *args, **kw)
+    got_chars = len(inp) - len(out)
+    got_bytes = len(inp.encode('utf-8')) - len(out.encode('utf-8'))
+    self.assertEqual((got_chars, got_bytes), (want_chars, want_bytes))
+
+  def test_poor_minification_quality(self):
+    self._test_minification_quality(754, 754,
+                                    reduce_empty_attributes=False,
+                                    remove_optional_attribute_quotes=False,
+                                    convert_charrefs=False)
+
+  def test_basic_minification_quality(self):
+    self._test_minification_quality(9408, 9398)
 
   def test_high_minification_quality(self):
-    import codecs
-    with codecs.open('htmlmin/tests/large_test.html', encoding='utf-8') as inpf:
-      inp = inpf.read()
-    out = self.minify(inp, remove_all_empty_space=True, remove_comments=True)
-    self.assertEqual(len(inp) - len(out), 12518)
+    self._test_minification_quality(12518, 12508,
+                                    remove_all_empty_space=True,
+                                    remove_comments=True)
 
 class TestMinifierObject(HTMLMinTestCase):
   __reference_texts__ = MINIFY_FUNCTION_TEXTS
@@ -393,7 +466,7 @@ class TestMinifierObject(HTMLMinTestCase):
     self.minifier.input(text[0][len(text[0]) // 2:])
     self.assertEqual(self.minifier.finalize(), text[1])
 
-  
+
 class TestMinifyFeatures(HTMLMinTestCase):
   __reference_texts__ = FEATURES_TEXTS
 
@@ -479,10 +552,25 @@ class TestMinifyFeatures(HTMLMinTestCase):
     text = self.__reference_texts__['dont_minify_scripts_or_styles']
     self.assertEqual(htmlmin.minify(text[0], pre_tags=[]), text[1])
 
-  def test_convert_charrefs_false(self):
-    text = self.__reference_texts__['convert_charrefs_false']
-    self.assertEqual(htmlmin.minify(text[0], convert_charrefs=False), text[1])
+def _make_test_convert_charrefs(tests):
+  def setUp(self): self.minify = htmlmin.minify
+  d = {'setUp': setUp}
 
+  def add_test(key, fmt, inp, out, convert_charrefs):
+    key = 'test_{}_{}'.format(key, ('off', 'on')[int(convert_charrefs)])
+    d[key] = _make_test(fmt.format(inp), fmt.format(out),
+                        convert_charrefs=convert_charrefs)
+
+  for key, test in tests.items():
+    inp = test[0]
+    add_test(key + '_in_attr_value', '<input value="{}">', inp, test[1], True)
+    add_test(key + '_in_attr_value', '<input value="{}">', inp, test[2], False)
+    add_test(key + '_in_text', '<p>{}', inp, test[3], True)
+    add_test(key + '_in_text', '<p>{}', inp, test[4], False)
+
+  return type('TestConvertCharrefs', (unittest.TestCase,), d)
+
+TestConvertCharrefs = _make_test_convert_charrefs(CONVERT_CHARREFS_TEXTS)
 
 class TestSelfClosingTags(HTMLMinTestCase):
   __reference_texts__ = SELF_CLOSE_TEXTS

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -197,7 +197,7 @@ FEATURES_TEXTS = {
   ),
   'remove_head_spaces': (
     '<head>  <title>   &#x2603;X  Y  &amp;  Z </title>  </head>',
-    '<head><title>&#x2603;X Y &amp; Z</title></head>',
+    '<head><title>☃X Y & Z</title></head>',
   ),
   'pre_respected_on_title': (
     '<head><title pre> Foo  bar </title></head>',
@@ -235,12 +235,11 @@ FEATURES_TEXTS = {
   ),
   'remove_entity_space': (
     '<p>Foo &#x20; bar &#32; baz</p>',
-    '<p>Foo &#x20; bar &#32; baz</p>',
+    '<p>Foo bar baz</p>',
   ),
-  # TODO: Fix, this should generate &amp;amp;
   'escape_after_close_tag_removal': (
     '<p><br>Foo &</br>amp; bar, <br>baz &am</br>p; qux</p>',
-    '<p><br>Foo &amp; bar, <br>baz &amp; qux</p>',
+    '<p><br>Foo &amp;amp; bar, <br>baz &amp;amp; qux</p>',
   ),
   # Note: the ‘]’ being eaten is Python bug in _markupbase.py, see
   # https://github.com/python/cpython/pull/24720
@@ -256,14 +255,14 @@ CONVERT_CHARREFS_TEXTS = {
     '&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;',
     u'&#34;\'\'\'<.\u03C0> &#34;',
     '&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;',
-    '&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;',
+    u'"\'\'\'&lt;.\u03C0> "',
     '&#34;&#39;&#39;&#39;&lt;&#46;&pi;&gt; &#34;',
   ),
   'not_escaped': (
     'Tiffany &amp; Co. H&M 1&amp;2 1&amp;2;',
     'Tiffany & Co. H&M 1&2 1&2;',
     'Tiffany &amp; Co. H&M 1&amp;2 1&amp;2;',
-    'Tiffany &amp; Co. H&M 1&amp;2 1&amp;2;',
+    'Tiffany & Co. H&amp;M 1&2 1&amp;2;',
     # TODO: Fix.  There is no named character reference ‘M’ and as such ‘&M’ is
     # perfectly valid way to write ‘&M’ according to HTML5.  Changing it to
     # ‘&M;’ changes the text.  This is probably Python bug.
@@ -273,14 +272,14 @@ CONVERT_CHARREFS_TEXTS = {
     ' 1&amp;2',
     ' 1&amp;2',
     ' 1&amp;2',
-    ' 1&amp;2',
+    ' 1&2',
     ' 1&amp;2',
   ),
   'no_semicolon': (
     '/?sect=2&para=5&par=8',
     '/?sect=2&para=5&par=8',
     '/?sect=2&para=5&par=8',
-    '/?sect=2&para=5&par=8',
+     '/?sect=2\u00B6=5&amp;par=8',
     # TODO: Fix.  There is no named character reference ‘par’ (even though
     # there’s ‘par;’) and as such ‘&par’ is perfectly valid way to write ‘&par’
     # according to HTML5.  Changing it to ‘&par;’ changes the text.  This is
@@ -429,10 +428,10 @@ class TestMinifyFunction(HTMLMinTestCase):
                                     convert_charrefs=False)
 
   def test_basic_minification_quality(self):
-    self._test_minification_quality(9408, 9398)
+    self._test_minification_quality(9595, 9582)
 
   def test_high_minification_quality(self):
-    self._test_minification_quality(12518, 12508,
+    self._test_minification_quality(12705, 12692,
                                     remove_all_empty_space=True,
                                     remove_comments=True)
 

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -203,11 +203,9 @@ FEATURES_TEXTS = {
     '<head><title pre> Foo  bar </title></head>',
     '<head><title> Foo  bar </title></head>',
   ),
-  # TODO: This is invalid HTML but regardless we should handle it sensibly
-  # rather than removing trailing whitespace everywhere.
   'missing_title_end': (
     '<head><title> Test </head><p>Foo <i> bar </i> and baz. </p>',
-    '<head><title>Test</head><p> Foo<i> bar</i> and baz.</p>',
+    '<head><title>Test</head><p>Foo <i> bar </i> and baz. </p>',
   ),
   'dont_minify_scripts_or_styles': (
     '<body>  <script>   X  </script>  <style>   X</style>   </body>',

--- a/htmlmin/tests/tests.py
+++ b/htmlmin/tests/tests.py
@@ -280,10 +280,7 @@ CONVERT_CHARREFS_TEXTS = {
   ),
   'no_semicolon': (
     '/?sect=2&para=5&par=8',
-    # TODO: Fix.  Inside of an attribute value, if named character reference
-    # does not end with a semicolon and is proceeded by an equal sign, it must
-    # be left intact.
-    u'/?sect=2\u00B6=5&par=8',
+    '/?sect=2&para=5&par=8',
     '/?sect=2&para=5&par=8',
     '/?sect=2&para=5&par=8',
     # TODO: Fix.  There is no named character reference ‘par’ (even though


### PR DESCRIPTION
Re-escape characters in data to minimise code further.  In data
sections only ampersand and less-than sign need to be escaped.  Since
characters are always shorter than their entities not escaping what
doesn’t need to saves space.  Furthermore, don’t escape ampersand in
situations in which HTML5 dictates it doesn’t need to be escape.
